### PR TITLE
No videos

### DIFF
--- a/src/dosertools/data_processing/csv.py
+++ b/src/dosertools/data_processing/csv.py
@@ -122,6 +122,9 @@ def generate_df(csv_location : typing.Union[str, bytes, os.PathLike], fname_form
 
     df_list = []
     csvs = get_csvs(csv_location)
+    if len(csvs) == 0:
+        raise FileNotFoundError("No CSVs found in csv_folder to process.")
+
     # Runs the processing for each csv in the folder.
     for csv in csvs:
         if verbose:

--- a/src/dosertools/data_processing/figures.py
+++ b/src/dosertools/data_processing/figures.py
@@ -3,6 +3,7 @@ import os
 import typing
 
 import pandas as pd
+import numpy as np
 import holoviews as hv
 hv.extension('bokeh')
 

--- a/src/dosertools/data_processing/integration.py
+++ b/src/dosertools/data_processing/integration.py
@@ -502,6 +502,9 @@ def binaries_to_csvs(images_folder: typing.Union[str, bytes, os.PathLike],
 
     df_list = []
     csvs = dpcsv.get_csvs(csv_folder)
+    if len(csvs) == 0:
+        raise FileNotFoundError("No CSVs found in csv_folder to process (no binaries were processed.)")
+
     # Runs the processing for each csv in the folder.
     for csv in csvs:
         sample_df = dpcsv.csv_to_dataframe(csv,short_fname_format,sampleinfo_format,optional_settings)

--- a/src/dosertools/tests/unit/test_data_processing.py
+++ b/src/dosertools/tests/unit/test_data_processing.py
@@ -432,6 +432,11 @@ class TestGenerateDF:
                 else:
                     assert results[column][0] == datetime.today().strftime('%Y%m%d')
 
+    def test_error_if_no_csvs(self, tmp_path):
+        with pytest.raises(FileNotFoundError,match="No CSVs"):
+            dpcsv.generate_df(tmp_path,self.fname_format,self.sampleinfo_format)
+
+
 class TestTruncateData:
     """
     Tests truncate_data.

--- a/src/dosertools/tests/unit/test_data_processing.py
+++ b/src/dosertools/tests/unit/test_data_processing.py
@@ -1147,10 +1147,19 @@ class TestBinariesToCSVs:
                                      optional_settings)
 
         out, err = capfd.readouterr()
-        print(out)
         assert "Processing 1 binary folder" in out
         assert "Finished processing binaries into csvs of D/D0 versus time." in out
 
+    def test_error_if_no_csvs(self,tmp_path,capfd,short_fname_format, sampleinfo_format):
+        csv_folder = tmp_path / "csv"
+        summary_folder = tmp_path / "summary"
+        binaries = tmp_path / "binary"
+        os.mkdir(csv_folder)
+        os.mkdir(summary_folder)
+        os.mkdir(binaries)
+
+        with pytest.raises(FileNotFoundError,match="No CSVs"):
+            integration.binaries_to_csvs(binaries, csv_folder, summary_folder, short_fname_format,sampleinfo_format)
 
 class TestVideosToCSVs:
     """

--- a/src/dosertools/tests/unit/test_image_processing.py
+++ b/src/dosertools/tests/unit/test_image_processing.py
@@ -188,9 +188,7 @@ class TestRemoveBGDrop:
         Checks if remove_bg_drop returns the bg_median given with the
         background drop removed
     """
-
-    # TODO: docstring
-
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_returns_correct_shape_array(self,bg_median):
         # Fails if remove_bg_drop does not return an ndarray of the correct
         # shape
@@ -198,6 +196,7 @@ class TestRemoveBGDrop:
         assert type(bg_median_drop_removed) is np.ndarray
         assert bg_median_drop_removed.shape == bg_median.shape
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_returns_bg_with_drop_removed(self,bg_median,bg_drop_removed):
         # Fails if remove_bg_drop does not remove the bg_drop from the bottom
         # of the background

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 filterwarnings =
   ignore:distutils:DeprecationWarning
-  ignore:Please use 'laplace':DeprecationWarning
+  ignore:Please use 'laplace' :DeprecationWarning


### PR DESCRIPTION
Add meaningful errors for scenarios where no videos were processed, which leads to no csvs being created (previously no csvs failed in a way that did not alert the user)